### PR TITLE
storage optimizaion fix

### DIFF
--- a/sdk/sdk_storage.go
+++ b/sdk/sdk_storage.go
@@ -88,26 +88,19 @@ func (plugin *StoragePluginServer) GetStates(ctx context.Context, req *grpc_stor
 }
 
 func (plugin *StoragePluginServer) PutState(stream grpc_storage.Store_PutStateServer) error {
-	rd := &plakar_grpc_storage.GrpcChunkReader{
-		StreamRecv: func() ([]byte, error) {
-			req, err := stream.Recv()
-			if err != nil {
-				return nil, err
-			}
-			return req.Chunk, nil
-		},
-	}
-
-	req, err := stream.Recv() // Read the first request to get the MAC,
+	req, err := stream.Recv() // Read the first request to get the MAC
 	if err != nil {
 		return err
 	}
 	mac := objects.MAC(req.Mac.Value)
-	rd.Buf.Write(req.Chunk) // Initialize the buffer with the first chunk
-	// this is hacky, to fix it we need to change the PutStateRequest to include only the MAC in the first request,
-	// and then send the chunks in later requests
 
-	size, err := plugin.storage.PutState(mac, rd)
+	size, err := plugin.storage.PutState(mac, plakar_grpc_storage.ReceiveChunks(func() ([]byte, error) {
+		req, err := stream.Recv()
+		if err != nil {
+			return nil, err
+		}
+		return req.Chunk, nil
+	}))
 	if err != nil {
 		return err
 	}
@@ -166,26 +159,19 @@ func (plugin *StoragePluginServer) GetPackfiles(ctx context.Context, req *grpc_s
 }
 
 func (plugin *StoragePluginServer) PutPackfile(stream grpc_storage.Store_PutPackfileServer) error {
-	rd := &plakar_grpc_storage.GrpcChunkReader{
-		StreamRecv: func() ([]byte, error) {
-			req, err := stream.Recv()
-			if err != nil {
-				return nil, err
-			}
-			return req.Chunk, nil
-		},
-	}
-
-	req, err := stream.Recv() // Read the first request to get the MAC,
+	req, err := stream.Recv() // Read the first request to get the MAC
 	if err != nil {
 		return err
 	}
 	mac := objects.MAC(req.Mac.Value)
-	rd.Buf.Write(req.Chunk) // Initialize the buffer with the first chunk
-	// this is hacky, to fix it we need to change the PutStateRequest to include only the MAC in the first request,
-	// and then send the chunks in later requests
 
-	size, err := plugin.storage.PutPackfile(mac, rd)
+	size, err := plugin.storage.PutPackfile(mac, plakar_grpc_storage.ReceiveChunks(func() ([]byte, error) {
+		req, err := stream.Recv()
+		if err != nil {
+			return nil, err
+		}
+		return req.Chunk, nil
+	}))
 	if err != nil {
 		return err
 	}
@@ -261,26 +247,19 @@ func (plugin *StoragePluginServer) GetLocks(ctx context.Context, req *grpc_stora
 }
 
 func (plugin *StoragePluginServer) PutLock(stream grpc_storage.Store_PutLockServer) error {
-	rd := &plakar_grpc_storage.GrpcChunkReader{
-		StreamRecv: func() ([]byte, error) {
-			req, err := stream.Recv()
-			if err != nil {
-				return nil, err
-			}
-			return req.Chunk, nil
-		},
-	}
-
-	req, err := stream.Recv() // Read the first request to get the MAC,
+	req, err := stream.Recv() // Read the first request to get the MAC
 	if err != nil {
 		return err
 	}
 	mac := objects.MAC(req.Mac.Value)
-	rd.Buf.Write(req.Chunk) // Initialize the buffer with the first chunk
-	// this is hacky, to fix it we need to change the PutStateRequest to include only the MAC in the first request,
-	// and then send the chunks in later requests
 
-	size, err := plugin.storage.PutLock(mac, rd)
+	size, err := plugin.storage.PutLock(mac, plakar_grpc_storage.ReceiveChunks(func() ([]byte, error) {
+		req, err := stream.Recv()
+		if err != nil {
+			return nil, err
+		}
+		return req.Chunk, nil
+	}))
 	if err != nil {
 		return err
 	}

--- a/sdk/sdk_storage.go
+++ b/sdk/sdk_storage.go
@@ -3,8 +3,6 @@ package sdk
 import (
 	"context"
 	"fmt"
-	"io"
-
 	"github.com/PlakarKorp/kloset/kcontext"
 	"github.com/PlakarKorp/kloset/objects"
 
@@ -130,25 +128,12 @@ func (plugin *StoragePluginServer) GetState(req *grpc_storage.GetStateRequest, s
 		return err
 	}
 
-	buf := make([]byte, plakar_grpc_storage.BufferSize)
-	for {
-		n, err := r.Read(buf)
-		if n > 0 {
-			if err := stream.Send(&grpc_storage.GetStateResponse{
-				Chunk: buf[:n],
-			}); err != nil {
-				return err
-			}
-		}
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
+	_, err = plakar_grpc_storage.SendChunks(r, func(chunk []byte) error {
+		return stream.Send(&grpc_storage.GetStateResponse{
+			Chunk: chunk,
+		})
+	})
+	return err
 }
 
 func (plugin *StoragePluginServer) DeleteState(ctx context.Context, req *grpc_storage.DeleteStateRequest) (*grpc_storage.DeleteStateResponse, error) {
@@ -221,25 +206,12 @@ func (plugin *StoragePluginServer) GetPackfile(req *grpc_storage.GetPackfileRequ
 		return err
 	}
 
-	buf := make([]byte, plakar_grpc_storage.BufferSize)
-	for {
-		n, err := r.Read(buf)
-		if n > 0 {
-			if err := stream.Send(&grpc_storage.GetPackfileResponse{
-				Chunk: buf[:n],
-			}); err != nil {
-				return err
-			}
-		}
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
+	_, err = plakar_grpc_storage.SendChunks(r, func(chunk []byte) error {
+		return stream.Send(&grpc_storage.GetPackfileResponse{
+			Chunk: chunk,
+		})
+	})
+	return err
 }
 
 func (plugin *StoragePluginServer) GetPackfileBlob(req *grpc_storage.GetPackfileBlobRequest, stream grpc_storage.Store_GetPackfileBlobServer) error {
@@ -251,25 +223,12 @@ func (plugin *StoragePluginServer) GetPackfileBlob(req *grpc_storage.GetPackfile
 		return err
 	}
 
-	buf := make([]byte, plakar_grpc_storage.BufferSize)
-	for {
-		n, err := r.Read(buf)
-		if n > 0 {
-			if err := stream.Send(&grpc_storage.GetPackfileBlobResponse{
-				Chunk: buf[:n],
-			}); err != nil {
-				return err
-			}
-		}
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
+	_, err = plakar_grpc_storage.SendChunks(r, func(chunk []byte) error {
+		return stream.Send(&grpc_storage.GetPackfileBlobResponse{
+			Chunk: chunk,
+		})
+	})
+	return err
 }
 
 func (plugin *StoragePluginServer) DeletePackfile(ctx context.Context, req *grpc_storage.DeletePackfileRequest) (*grpc_storage.DeletePackfileResponse, error) {
@@ -342,25 +301,12 @@ func (plugin *StoragePluginServer) GetLock(req *grpc_storage.GetLockRequest, str
 		return err
 	}
 
-	buf := make([]byte, plakar_grpc_storage.BufferSize)
-	for {
-		n, err := r.Read(buf)
-		if n > 0 {
-			if err := stream.Send(&grpc_storage.GetLockResponse{
-				Chunk: buf[:n],
-			}); err != nil {
-				return err
-			}
-		}
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
+	_, err = plakar_grpc_storage.SendChunks(r, func(chunk []byte) error {
+		return stream.Send(&grpc_storage.GetLockResponse{
+			Chunk: chunk,
+		})
+	})
+	return err
 }
 
 func (plugin *StoragePluginServer) DeleteLock(ctx context.Context, req *grpc_storage.DeleteLockRequest) (*grpc_storage.DeleteLockResponse, error) {


### PR DESCRIPTION
refactors sdk_storage file to improve efficiency by replacing manual buffer management with reusable utility functions for handling streaming data. Additionally, it simplifies the implementation of several methods in the by using the `plakar_grpc_storage` helper funcion.

however to use those helper functions, pls look and merge [plakar 1180](https://github.com/PlakarKorp/plakar/pull/1180)