### PR TITLE
importer: unlock OpenReader

### DIFF
--- a/importer.go
+++ b/importer.go
@@ -167,8 +167,8 @@ func (plugin *importerPluginServer) OpenReader(req *grpc_importer.OpenReaderRequ
 	pathname := req.Pathname
 
 	plugin.mu.Lock()
-	defer plugin.mu.Unlock()
 	reader, ok := plugin.holdingReaders[pathname]
+	plugin.mu.Unlock()
 
 	if !ok {
 		return fmt.Errorf("no reader for pathname %s", pathname)


### PR DESCRIPTION
We don't need to keep the lock for the whole reading operation, it's just needed to guard the access to the holdingReaders map.